### PR TITLE
FIX #82 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The following Invoke and Query APIs are available from both CLI and REST, and ha
 
 ##Environment Setup
 
-Please review instructions on setting up the [Development Environment](https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/devenv.md) as well as the setting up the [Sandbox Environment](https://github.com/hyperledger/fabric/blob/master/docs/Setup/Chaincode-setup.md) to execute the chaincode.
+Please review instructions on setting up the [Development Environment](https://github.com/hyperledger/fabric/blob/master/docs/source/dev-setup/devenv.rst) as well as the setting up the [Sandbox Environment](https://github.com/hyperledger/fabric/blob/master/docs/source/Setup/Chaincode-setup.rst) to execute the chaincode.
 
 ## Running the Application
 


### PR DESCRIPTION
Fixed documentation broken links. Now dev-env setup and chaincode setup document reference links are pointing to .rst format.